### PR TITLE
Fixed bug introduced by change in bitstrings 4.1.0.

### DIFF
--- a/ntripstreams/ntripstreams.py
+++ b/ntripstreams/ntripstreams.py
@@ -524,6 +524,7 @@ class NtripStream:
                 else:
                     self.rtcmFrameBuffer = BitStream()
             if self.rtcmFramePreample and self.rtcmFrameBuffer.length >= 48:
+                self.rtcmFrameBuffer.pos = 0
                 (rtcmPreAmple, rtcmPayloadLength) = self.rtcmFrameBuffer.peeklist(
                     rtcm3FrameHeaderFormat
                 )

--- a/ntripstreams/ntripstreams.py
+++ b/ntripstreams/ntripstreams.py
@@ -477,7 +477,7 @@ class NtripStream:
         rtcmFrameComplete = False
         while not rtcmFrameComplete:
             timeStamp = time()
-            if self.rtcmFrameBuffer.length < 2048:
+            if self.rtcmFrameBuffer.length < 4096:
                 if self.ntripStreamChunked:
                     try:
                         rawLine = await self.ntripReader.readuntil(b"\r\n")

--- a/ntripstreams/ntripstreams.py
+++ b/ntripstreams/ntripstreams.py
@@ -477,7 +477,7 @@ class NtripStream:
         rtcmFrameComplete = False
         while not rtcmFrameComplete:
             timeStamp = time()
-            if self.rtcmFrameBuffer.length < 4096:
+            if self.rtcmFrameBuffer.length < 8192:
                 if self.ntripStreamChunked:
                     try:
                         rawLine = await self.ntripReader.readuntil(b"\r\n")


### PR DESCRIPTION
Buffer position may not be at zero position when preforming peek operation. This change explicitly sets it to zero. 